### PR TITLE
Fix #60

### DIFF
--- a/gatsby/src/assets/scss/blocks/_banner.scss
+++ b/gatsby/src/assets/scss/blocks/_banner.scss
@@ -2,7 +2,7 @@
   @apply bg-cover;
   @apply bg-center;
   @apply bg-no-repeat;
-  @apply bg-fixed;
+  @apply bg-scroll;
 
   height: 60vh;
 
@@ -15,4 +15,10 @@
 .banner,
 .banner + * {
   --flow-space: #{rem-calc(90)};
+}
+
+@media (min-width: 640px) {
+  .banner {
+    @apply bg-fixed;
+  }
 }


### PR DESCRIPTION
Added media query to fix ios bg image bug

`background-size: cover;` and `background-attachment: fixed; ` seem to have perf issues on mob devices so safari on ios has removed.