### PR TITLE
Fix: Added concurrent var to build script

### DIFF
--- a/gatsby/package.json
+++ b/gatsby/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "develop": "gatsby develop",
     "clean": "gatsby clean",
-    "build": "cross-env gatsby build --log-pages",
+    "build": "GATSBY_CONCURRENT_DOWNLOAD=5 cross-env gatsby build --log-pages",
     "clean-develop": "gatsby clean && gatsby develop",
     "clean-build": "gatsby clean && gatsby build",
     "start": "npm run develop",


### PR DESCRIPTION
**Description:**

Netlify is erroring on build with a timeout error.

From the looks of it adding GATSBY_CONCURRENT_DOWNLOAD=5 seems to help get around this issue.
https://github.com/gatsbyjs/gatsby/issues/29744

**Ticket/Rindle Card Link:** 

n/a

**Notes:**

n/a

**Resources/dependencies:**

n/a
